### PR TITLE
remove revgeo

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -78,7 +78,6 @@ Suggests:
     readr,
     RefManageR,
     reprex,
-    revgeo,
     rgdal,
     rgeos,
     rgrass7 (>= 0.2-1),


### PR DESCRIPTION
Instead of `revgeo::revgeo()`, we will use `tmaptools::rev_geocode_OSM()` in chapter 14. This way we spare one dependency (especially because we would have to use the gitub version of **revgeo** and it does not seem that the package is well maintained at the moment) since we already use **tmaptools** as a dependency.
But before merging here, we have to merge https://github.com/Robinlovelace/geocompr/tree/rewrite_geom into the main branch. But this is still work in progress.